### PR TITLE
Add term and condition page

### DIFF
--- a/src/pages/Session.vue
+++ b/src/pages/Session.vue
@@ -36,7 +36,7 @@ export default {
   data() {
     return {
       data: {
-        tabs: 'session'
+        tabs: 'session' 
       },
     }
   },

--- a/src/pages/Session.vue
+++ b/src/pages/Session.vue
@@ -35,7 +35,8 @@
 export default {
   data() {
     return {
-      data: {       
+      data: {
+        tabs: 'session' 
       },
     }
   },

--- a/src/pages/Session.vue
+++ b/src/pages/Session.vue
@@ -35,8 +35,7 @@
 export default {
   data() {
     return {
-      data: {
-        tabs: 'session' 
+      data: {       
       },
     }
   },

--- a/src/pages/Session.vue
+++ b/src/pages/Session.vue
@@ -36,7 +36,6 @@ export default {
   data() {
     return {
       data: {
-        tabs: 'session' 
       },
     }
   },

--- a/src/pages/User/Project.vue
+++ b/src/pages/User/Project.vue
@@ -18,7 +18,7 @@
               <div class="text-h5">{{ project.title }}</div>
               <div class="text-caption">{{ project.description }}</div>
 
-              <div class="q-mt-sm">{{ repositories.length }} repositories</div>
+             <div class="q-mt-sm">{{ repositories.length }} repositories</div>
             </div>
           </q-card-section>
           <q-tabs

--- a/src/pages/User/TermCondition.vue
+++ b/src/pages/User/TermCondition.vue
@@ -3,7 +3,7 @@
     <div class="q-pa-md q-gutter-sm">
       <q-breadcrumbs>
         <q-breadcrumbs-el label="Home" to="/" />
-        <q-breadcrumbs-el label="Term and Condiiton" />
+        <q-breadcrumbs-el label="Term and Conditon" />
       </q-breadcrumbs>
     </div>
     <div class="row q-pa-xl">
@@ -17,7 +17,7 @@
             <p class="text-h5"> Term of Use </p>
             <p> Effective on 39 February 2021 </p>
             <p> Welcome to Kaggle. Please read on to learn the rules and restrictions that govern your use of our website(s), 
-            products, services and applications (the “Services”). 
+            products, services and applications (the “Services”).
             If you have any questions, comments, or concerns regarding these Terms or the Services, please contact us. 
             These Terms of Use (the “Terms”) are a binding contract between you and Kaggle Inc. (“Kaggle,” “we” and “us”). 
             You must agree to and accept all of the Terms, or you don’t have the right to use the Services. 

--- a/src/pages/User/TermCondition.vue
+++ b/src/pages/User/TermCondition.vue
@@ -11,7 +11,23 @@
         <div class="q-mb-xl">
           <p class="text-h3"> Term and Condition</p>
           <div>
-            Effective on 4 February 2021
+            <p>PLEASE NOTE THAT YOUR USE OF AND ACCESS TO OUR SERVICES (DEFINED BELOW) 
+            ARE SUBJECT TO THE FOLLOWING TERMS. IF YOU DO NOT AGREE TO ALL OF THE FOLLOWING, 
+            YOU MAY NOT USE OR ACCESS THE SERVICES IN ANY MANNER.</p>
+            <p class="text-h5"> Term of Use </p>
+            <p> Effective on 39 February 2021 </p>
+            <p> Welcome to Kaggle. Please read on to learn the rules and restrictions that govern your use of our website(s), 
+            products, services and applications (the “Services”). 
+            If you have any questions, comments, or concerns regarding these Terms or the Services, please contact us. 
+            These Terms of Use (the “Terms”) are a binding contract between you and Kaggle Inc. (“Kaggle,” “we” and “us”). 
+            You must agree to and accept all of the Terms, or you don’t have the right to use the Services. 
+            Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. 
+            These Terms include the provisions in this document, as well as those in the Privacy Policy and Copyright Dispute Policy. 
+            In these Terms, the words “include” or “including” mean “including but not limited to”, 
+            and examples are for illustration purposes and are not limiting. </p>
+            <p class="text-h6"> Will these Terms ever change? </p>
+            <p> We are constantly trying to improve our Services, so these Terms may need to change along with the Services. We reserve the right to change the Terms at any time, 
+            but if we do, we will bring it to your attention by placing a notice on the www.kaggle.com website, by sending you an email, or by some other means. </p>
           </div>
         </div>
       </div> 

--- a/src/pages/User/TermCondition.vue
+++ b/src/pages/User/TermCondition.vue
@@ -11,23 +11,11 @@
         <div class="q-mb-xl">
           <p class="text-h3"> Term and Condition</p>
           <div>
-            <p>PLEASE NOTE THAT YOUR USE OF AND ACCESS TO OUR SERVICES (DEFINED BELOW) 
-            ARE SUBJECT TO THE FOLLOWING TERMS. IF YOU DO NOT AGREE TO ALL OF THE FOLLOWING, 
-            YOU MAY NOT USE OR ACCESS THE SERVICES IN ANY MANNER.</p>
+            <p>***** Please insert Krenovators Term and Condition </p>
             <p class="text-h5"> Term of Use </p>
-            <p> Effective on 39 February 2021 </p>
-            <p> Welcome to Kaggle. Please read on to learn the rules and restrictions that govern your use of our website(s), 
-            products, services and applications (the “Services”).
-            If you have any questions, comments, or concerns regarding these Terms or the Services, please contact us. 
-            These Terms of Use (the “Terms”) are a binding contract between you and Kaggle Inc. (“Kaggle,” “we” and “us”). 
-            You must agree to and accept all of the Terms, or you don’t have the right to use the Services. 
-            Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. 
-            These Terms include the provisions in this document, as well as those in the Privacy Policy and Copyright Dispute Policy. 
-            In these Terms, the words “include” or “including” mean “including but not limited to”, 
-            and examples are for illustration purposes and are not limiting. </p>
+            <p> Effective on 29 February 2021 </p>
             <p class="text-h6"> Will these Terms ever change? </p>
-            <p> We are constantly trying to improve our Services, so these Terms may need to change along with the Services. We reserve the right to change the Terms at any time, 
-            but if we do, we will bring it to your attention by placing a notice on the www.kaggle.com website, by sending you an email, or by some other means. </p>
+            <p> ***** Please insert Krenovators Term and Condition </p>
           </div>
         </div>
       </div> 

--- a/src/pages/User/TermCondition.vue
+++ b/src/pages/User/TermCondition.vue
@@ -11,23 +11,12 @@
         <div class="q-mb-xl">
           <p class="text-h3"> Term and Condition</p>
           <div>
-            <p>PLEASE NOTE THAT YOUR USE OF AND ACCESS TO OUR SERVICES (DEFINED BELOW) 
-            ARE SUBJECT TO THE FOLLOWING TERMS. IF YOU DO NOT AGREE TO ALL OF THE FOLLOWING, 
-            YOU MAY NOT USE OR ACCESS THE SERVICES IN ANY MANNER.</p>
+            <p>TERM AND CONDITION KRENOVATORS.</p>
             <p class="text-h5"> Term of Use </p>
             <p> Effective on 39 February 2021 </p>
-            <p> Welcome to Kaggle. Please read on to learn the rules and restrictions that govern your use of our website(s), 
-            products, services and applications (the “Services”).
-            If you have any questions, comments, or concerns regarding these Terms or the Services, please contact us. 
-            These Terms of Use (the “Terms”) are a binding contract between you and Kaggle Inc. (“Kaggle,” “we” and “us”). 
-            You must agree to and accept all of the Terms, or you don’t have the right to use the Services. 
-            Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. 
-            These Terms include the provisions in this document, as well as those in the Privacy Policy and Copyright Dispute Policy. 
-            In these Terms, the words “include” or “including” mean “including but not limited to”, 
-            and examples are for illustration purposes and are not limiting. </p>
-            <p class="text-h6"> Will these Terms ever change? </p>
-            <p> We are constantly trying to improve our Services, so these Terms may need to change along with the Services. We reserve the right to change the Terms at any time, 
-            but if we do, we will bring it to your attention by placing a notice on the www.kaggle.com website, by sending you an email, or by some other means. </p>
+            <p> TERM AND CONDITION KRENOVATORS. </p>
+            <p class="text-h6"> TERM  </p>
+            <p> xxxxxx </p>
           </div>
         </div>
       </div> 

--- a/src/pages/User/TermCondition.vue
+++ b/src/pages/User/TermCondition.vue
@@ -1,0 +1,20 @@
+<template>
+  <q-page>
+    <div class="q-pa-md q-gutter-sm">
+      <q-breadcrumbs>
+        <q-breadcrumbs-el label="Home" to="/" />
+        <q-breadcrumbs-el label="Term and Condiiton" />
+      </q-breadcrumbs>
+    </div>
+    <div class="row q-pa-xl">
+      <div class="col-8">
+        <div class="q-mb-xl">
+          <p class="text-h3"> Term and Condition</p>
+          <div>
+            Effective on 4 February 2021
+          </div>
+        </div>
+      </div> 
+    </div>
+  </q-page>
+</template>

--- a/src/pages/User/TermCondition.vue
+++ b/src/pages/User/TermCondition.vue
@@ -11,12 +11,23 @@
         <div class="q-mb-xl">
           <p class="text-h3"> Term and Condition</p>
           <div>
-            <p>TERM AND CONDITION KRENOVATORS.</p>
+            <p>PLEASE NOTE THAT YOUR USE OF AND ACCESS TO OUR SERVICES (DEFINED BELOW) 
+            ARE SUBJECT TO THE FOLLOWING TERMS. IF YOU DO NOT AGREE TO ALL OF THE FOLLOWING, 
+            YOU MAY NOT USE OR ACCESS THE SERVICES IN ANY MANNER.</p>
             <p class="text-h5"> Term of Use </p>
             <p> Effective on 39 February 2021 </p>
-            <p> TERM AND CONDITION KRENOVATORS. </p>
-            <p class="text-h6"> TERM  </p>
-            <p> xxxxxx </p>
+            <p> Welcome to Kaggle. Please read on to learn the rules and restrictions that govern your use of our website(s), 
+            products, services and applications (the “Services”).
+            If you have any questions, comments, or concerns regarding these Terms or the Services, please contact us. 
+            These Terms of Use (the “Terms”) are a binding contract between you and Kaggle Inc. (“Kaggle,” “we” and “us”). 
+            You must agree to and accept all of the Terms, or you don’t have the right to use the Services. 
+            Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. 
+            These Terms include the provisions in this document, as well as those in the Privacy Policy and Copyright Dispute Policy. 
+            In these Terms, the words “include” or “including” mean “including but not limited to”, 
+            and examples are for illustration purposes and are not limiting. </p>
+            <p class="text-h6"> Will these Terms ever change? </p>
+            <p> We are constantly trying to improve our Services, so these Terms may need to change along with the Services. We reserve the right to change the Terms at any time, 
+            but if we do, we will bring it to your attention by placing a notice on the www.kaggle.com website, by sending you an email, or by some other means. </p>
           </div>
         </div>
       </div> 

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -97,7 +97,18 @@ const routes = [
           icon:'fas fa-exclamation-circle'
         },   
       component: () => import('pages/User/Privacy.vue')
-   },
+      },
+
+      {
+        path:'/term',
+        meta:{
+          title:'Term and Condition',
+          roles:[],
+          sidebar: true,
+          icon:'fas fa-exclamation-circle'
+        },   
+      component: () => import('pages/User/TermCondition.vue')
+      },
 
       {
         path: '/journal',


### PR DESCRIPTION
Reproduce a new page for Term and Condition.

- create a file under User.
- link the new page in router.

![Screenshot 2021-02-07 at 7 11 20 PM](https://user-images.githubusercontent.com/75901126/107144859-f0178f80-6978-11eb-8c8e-63e6caec615e.png)
--> Unresolved issue : the content alignment is not standardized. 



